### PR TITLE
Update apt

### DIFF
--- a/dpkg/apt
+++ b/dpkg/apt
@@ -1,3 +1,4 @@
 influxdb
+influxdb-client
 telegraf
 grafana


### PR DESCRIPTION
scheint so als muss der influxdb-client jetzt einzeln installiert werden